### PR TITLE
fix: supporting Unix linebreaks style in Window environment

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,3 @@
-/*eslint linebreak-style: ["error", "windows"]*/
 module.exports = {
   root: true,
   parser: '@typescript-eslint/parser',
@@ -42,7 +41,7 @@ module.exports = {
     'no-use-before-define': 'off',
     'react/jsx-filename-extension': [2, { extensions: ['.js', '.jsx', '.ts', '.tsx'] }],
     'react/no-array-index-key': 'off',
-    'linebreak-style': ['error', 'windows']
+    'linebreak-style': ['error', 'windows'],
   },
   overrides: [
     {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,4 @@
+/*eslint linebreak-style: ["error", "windows"]*/
 module.exports = {
   root: true,
   parser: '@typescript-eslint/parser',
@@ -41,6 +42,7 @@ module.exports = {
     'no-use-before-define': 'off',
     'react/jsx-filename-extension': [2, { extensions: ['.js', '.jsx', '.ts', '.tsx'] }],
     'react/no-array-index-key': 'off',
+    'linebreak-style': ['error', 'windows']
   },
   overrides: [
     {


### PR DESCRIPTION
Supporting Unix linebreaks style in Window environment
-------------
'Expected linebreaks to be 'LF' but found 'CRLF' linebreak-style error' happens on Window env

For more info, see this thread in stackoverflow:
https://stackoverflow.com/questions/37826449/expected-linebreaks-to-be-lf-but-found-crlf-linebreak-style
